### PR TITLE
Adds Feedback Portal Types

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,0 +1,86 @@
+import faker from 'faker/locale/en';
+import { ObjectId } from 'mongodb';
+import { Meta, makeMetaField } from '.';
+
+function makeDummyList<T>(
+    makeDummyObject: () => T,
+    amount?: number,
+    callback?: (d: T) => T
+): T[] {
+    const list = [];
+    const iterations = amount || 10;
+    for (let i = 0; i < iterations; i += 1) {
+        let dummyObject = makeDummyObject();
+        if (callback) dummyObject = callback(dummyObject);
+        list.push(dummyObject);
+    }
+    return list;
+}
+
+export interface ReportReply {
+    content: string;
+    meta: Meta;
+}
+
+export const makeReportReply = (): ReportReply => ({
+    content: faker.lorem.paragraph(),
+    meta: makeMetaField(),
+});
+
+export const makeReportReplies = (
+    amount?: number,
+    callback?: (t: ReportReply) => ReportReply // for transforming each reply if needed
+): ReportReply[] => makeDummyList(makeReportReply, amount, callback);
+
+export interface Report {
+    description: string;
+    resolved?: boolean;
+    replies: ReportReply[];
+}
+
+export const makeReport = (): Report => ({
+    description: faker.lorem.paragraphs(),
+    resolved: faker.random.boolean(),
+    replies: makeReportReplies(),
+});
+
+export const makeReports = (
+    amount?: number,
+    callback?: (t: Report) => Report // for transforming each reply if needed
+): Report[] => makeDummyList(makeReport, amount, callback);
+
+export interface FeedbackReport<T extends string | ObjectId = string>
+    extends Report {
+    _id: T;
+    meta: Meta<T>;
+}
+
+export const makeFeedbackReport = (): FeedbackReport => ({
+    ...makeReport(),
+    meta: makeMetaField(),
+    _id: faker.random.alphaNumeric(12),
+});
+
+export const makeFeedbackReports = (
+    amount?: number,
+    callback?: (t: FeedbackReport) => FeedbackReport // for transforming each feedback report if needed
+): FeedbackReport[] => makeDummyList(makeFeedbackReport, amount, callback);
+
+export interface BugReport<T extends string | ObjectId = string>
+    extends Report {
+    _id: T;
+    meta: Meta<T>;
+    townhallId: T;
+}
+
+export const makeBugReport = (): BugReport => ({
+    ...makeReport(),
+    meta: makeMetaField(),
+    _id: faker.random.alphaNumeric(12),
+    townhallId: faker.random.alphaNumeric(12),
+});
+
+export const makeBugReports = (
+    amount?: number,
+    callback?: (t: BugReport) => BugReport // for transforming each bug report if needed
+): BugReport[] => makeDummyList(makeBugReport, amount, callback);

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ export interface Pagination {
 export * from './auth';
 export * from './townhall';
 export * from './invites';
-
+export * from './feedback';
 export function makeGenFn<T>(fn: () => T) {
     return (iterations: number) => {
         const ret: T[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,7 @@ export * from './auth';
 export * from './townhall';
 export * from './invites';
 export * from './feedback';
+
 export function makeGenFn<T>(fn: () => T) {
     return (iterations: number) => {
         const ret: T[] = [];


### PR DESCRIPTION
Adds types for the feedback portal. The following interfaces were added:

- ReportReply (Originally, this was just called Reply, but I noticed that there is already a Reply interface being exported, so I changed the name of my interface)
- Report
- FeedbackReport
- BugReport

I also implemented the respective functions that make dummy data for each of the interfaces described above.
