### PR TITLE
removed userId field from RatingForm

### DIFF
--- a/src/townhall.ts
+++ b/src/townhall.ts
@@ -379,7 +379,6 @@ export const makeTownhalls = (
 };
 
 export interface RatingForm {
-    userId?: string;
     values: Record<string, number | null>;
     feedback: string;
 }


### PR DESCRIPTION
No need to pass the userId in the ratingForm since we can get it from cookies.